### PR TITLE
Mekhi/fix private message modal

### DIFF
--- a/client/src/app/(main)/message/private/[conversationId]/page.tsx
+++ b/client/src/app/(main)/message/private/[conversationId]/page.tsx
@@ -12,7 +12,7 @@ export default function Page({
         display: "grid",
       }}
     >
-      <Conversation conversationId={conversationId} />
+      <Conversation conversationId={conversationId} isPrivateConversation />
     </div>
   );
 }

--- a/client/src/lib/store/message.ts
+++ b/client/src/lib/store/message.ts
@@ -1,21 +1,24 @@
 import { create } from "zustand";
-// import { Tables } from "../types/database.types";
 import { MessageCardProps } from "@/ui/messaging/MessageCard";
 
-// TODO Get the actual types from the database
-// export type MessageType = Tables<"public_message" | "private_message">;
 
 // state of the hook
 interface MessageState {
   messages: MessageCardProps[];
+  isPrivateConversation: boolean;
   addMessage: (newMessage: MessageCardProps) => void;
   clearMessages: () => void;
+  setConversationType: (conversationType: boolean) => void;
 }
 
 // hook that will be access in UI components
 export const useMessage = create<MessageState>()((set) => ({
   messages: [],
+  isPrivateConversation: false,
   addMessage: (newMessage) =>
     set((state) => ({ messages: [...state.messages, newMessage] })),
   clearMessages: () => set(() => ({ messages: [] })),
+  setConversationType: (conversationType) => {
+    set((state) => ({ ...state, isPrivateConversation: conversationType }));
+  },
 }));

--- a/client/src/ui/messaging/Conversation.tsx
+++ b/client/src/ui/messaging/Conversation.tsx
@@ -12,8 +12,14 @@ import { useSubscribeConversation } from "@/lib/hooks/useSubscribeConversation";
  * This is a UI container that holds all messages for a particular conversation
  * @param {string} conversationId - ID used to subscribe users to listen to incoming messages
  */
-export function Conversation({ conversationId }: { conversationId: string }) {
-  const { addMessage, clearMessages } = useMessage();
+export function Conversation({
+  conversationId,
+  isPrivateConversation = false,
+}: {
+  conversationId: string;
+  isPrivateConversation?: boolean;
+}) {
+  const { addMessage, clearMessages, setConversationType } = useMessage();
   const { profile } = useProfile();
   const [numNewMessages, setNumNewMessages] = useState(0); // used for rendering new message notification
   const bottomRef = useRef<null | HTMLDivElement>(null); // used for scrolling down the page
@@ -34,6 +40,10 @@ export function Conversation({ conversationId }: { conversationId: string }) {
     clearMessages();
     return () => clearMessages();
   }, [conversationId, clearMessages]);
+
+  useEffect(() => {
+    setConversationType(isPrivateConversation);
+  }, [setConversationType, isPrivateConversation]);
 
   return (
     <div

--- a/client/src/ui/messaging/MessageCard.tsx
+++ b/client/src/ui/messaging/MessageCard.tsx
@@ -2,6 +2,7 @@ import { Card, CardHeader, Typography } from "@mui/material";
 import { AvatarTypes, ProfileAvatar } from "../ProfileAvatar";
 import { memo, useEffect, useState } from "react";
 import { useProfile } from "../../lib/store/profile";
+import { useMessage } from "@/lib/store/message";
 import { PrivateMessageModal } from "./PrivateMessageModal";
 export interface MessageCardProps {
   avatar: AvatarTypes;
@@ -29,9 +30,9 @@ export const MessageCard = memo(function MessageCard({
   message,
   scrollDown,
 }: MessageCardProps) {
-  // TODO: Make CardHeader match the UI in figma file
   // TODO: Add upVotes and downVotes component
   const { profile } = useProfile();
+  const { isPrivateConversation: isPrivateMessage } = useMessage();
   const messageDate = new Date(timestamp);
 
   const [openModal, setOpenModal] = useState(false);
@@ -43,10 +44,9 @@ export const MessageCard = memo(function MessageCard({
     if (scrollDown) scrollDown();
   });
 
-  // TODO: Decouple boolean logic and setting prevDate state
-  // TODO: This needs to get tested
-
   const messageSenderIsCurrentUser = profile?.username === sender_username;
+  const doRenderPrivateMessageModal =
+    messageSenderIsCurrentUser === false && !isPrivateMessage;
 
   return (
     <>
@@ -59,15 +59,15 @@ export const MessageCard = memo(function MessageCard({
         <CardHeader
           avatar={
             <ProfileAvatar
-              onClick={messageSenderIsCurrentUser ? () => {} : handleOpenModal}
+              onClick={doRenderPrivateMessageModal ? handleOpenModal : () => {}}
               avatar={avatar}
               sx={{
                 border: messageSenderIsCurrentUser
                   ? "3px #496FFF solid"
                   : "none",
-                cursor: messageSenderIsCurrentUser ? "default" : "pointer",
+                cursor: doRenderPrivateMessageModal ? "pointer" : "default",
                 "&:hover": {
-                  opacity: messageSenderIsCurrentUser ? "1" : ".5",
+                  opacity: doRenderPrivateMessageModal ? ".5" : "1",
                 },
               }}
             />

--- a/client/src/ui/messaging/NewMessageNotificationModal.tsx
+++ b/client/src/ui/messaging/NewMessageNotificationModal.tsx
@@ -29,6 +29,7 @@ export function NewMessagesNotificationModal({
         "&.MuiSnackbar-root": { top: "80px", justifyContent: "center" }, // positions Snackbar within ConversationBody
         position: "sticky",
         height: "0", // takes the NewMessagesNotification out of the document flow, fixing padding issues with MessageList when this component renders
+        zIndex: 1,
       }}
     >
       <Chip

--- a/client/src/ui/messaging/PrivateMessageModal.tsx
+++ b/client/src/ui/messaging/PrivateMessageModal.tsx
@@ -39,7 +39,13 @@ export function PrivateMessageModal({
     router.push(`/message/private/private_conversationID`);
   };
   return (
-    <Modal open={isOpen} onClose={onClose}>
+    <Modal
+      sx={{
+        zIndex: 2,
+      }}
+      open={isOpen}
+      onClose={onClose}
+    >
       <Box
         sx={{
           position: "absolute",

--- a/client/src/ui/messaging/PrivateMessageModal.tsx
+++ b/client/src/ui/messaging/PrivateMessageModal.tsx
@@ -36,7 +36,7 @@ export function PrivateMessageModal({
     // TODO add backend logic to send message into conversation table, and create a new conversation table if it has not been created yet
     setCurrentMessage("");
     // TODO Replace hardcoded value with the real conversationID
-    router.push(`/message/private/${receiverUsername}_conversationID`);
+    router.push(`/message/private/private_conversationID`);
   };
   return (
     <Modal open={isOpen} onClose={onClose}>


### PR DESCRIPTION
Bug fixes
- Fixed demo route when private message button is pressed in PrivateMessageModal
- PrivateMessageModal now renders on top of the NewMessagesNotificationModal
- PrivateMssageModal can only be rendered if the current user is in the company threads conversation, not the private conversation