### PR TITLE
JobCard-Stats

### DIFF
--- a/client/src/lib/utils/Application/FetchOpportunityStats.ts
+++ b/client/src/lib/utils/Application/FetchOpportunityStats.ts
@@ -1,0 +1,28 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { createSupabaseClient } from "@/lib/supabase/client";
+import { Database } from "@/lib/types/database.types";
+
+/**
+ * Fetches opportunity tracking data for a given opportunity_id.
+ * @param opportunity_id - Opportunity ID
+ * @param supabase - Supabase client
+ * @returns {data: Opportunity tracking data, error: Error}
+ */
+
+export async function FetchOpportunityStats(
+    opportunity_id: string,
+    supabase: SupabaseClient = createSupabaseClient()
+): Promise<{ data: Database["public"]["Tables"]["opportunity_tracking"]["Row"][] | null; error: string | null }> {
+    const { data, error } = await supabase
+        .from("opportunity_tracking")
+        .select("*")
+        .eq("opportunity_id", opportunity_id)
+        .order("month", { ascending: true });
+
+    if (error) {
+        console.error("Error fetching opportunity tracking data:", error.message);
+        return { data: null, error: error.message };
+    }
+    console.log(data);
+    return { data: data, error: null };
+}

--- a/client/src/ui/track/ApplicationStatsModal.tsx
+++ b/client/src/ui/track/ApplicationStatsModal.tsx
@@ -31,9 +31,9 @@ interface OpportunityTrackingData {
   }
 
 export interface ApplicationStatsModalProps {
-  open: boolean; // Controls the modal visibility
-  onClose: () => void; // Handler to close the modal
-  opportunity_id: string; // ID of the opportunity to fetch stats for
+  open: boolean; 
+  onClose: () => void; 
+  opportunity_id: string; 
 }
 
 export function ApplicationStatsModal({
@@ -41,9 +41,9 @@ export function ApplicationStatsModal({
   onClose,
   opportunity_id,
 }: ApplicationStatsModalProps) {
-  const [opportunityData, setOpportunityData] = useState<OpportunityTrackingData[]>([]); // State for fetched tracking data
+  const [opportunityData, setOpportunityData] = useState<OpportunityTrackingData[]>([]); 
   const [loading, setLoading] = useState(false); // Loading state
-  const [error, setError] = useState<string | null>(null); // Error state
+  const [error, setError] = useState<string | null>(null); 
 
   const months = [
     "Jan", "Feb", "Mar", "Apr", "May", "June", 

--- a/client/src/ui/track/ApplicationStatsModal.tsx
+++ b/client/src/ui/track/ApplicationStatsModal.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState, useMemo } from "react";
+import { Box, Modal, Typography, CircularProgress } from "@mui/material";
+import { BarChart } from "@mui/x-charts";
+import { FetchOpportunityStats } from "@/lib/utils/Application/FetchOpportunityStats";
+
+const style = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 600,
+  height: 400,
+  bgcolor: "background.paper",
+  border: "solid 3px #e0e4f2",
+  p: 4,
+  borderRadius: "10px",
+  justifyContent: "center",
+  alignItems: "center",
+  display: "flex",
+  flexDirection: "column",
+};
+
+// Define the structure of opportunity tracking data
+interface OpportunityTrackingData {
+    month: number | null;
+    rejected: number | null;
+    online_assessment: number | null;
+    interviewing: number | null;
+    offer: number | null;
+    applied: number | null;
+  }
+
+export interface ApplicationStatsModalProps {
+  open: boolean; // Controls the modal visibility
+  onClose: () => void; // Handler to close the modal
+  opportunity_id: string; // ID of the opportunity to fetch stats for
+}
+
+export function ApplicationStatsModal({
+  open,
+  onClose,
+  opportunity_id,
+}: ApplicationStatsModalProps) {
+  const [opportunityData, setOpportunityData] = useState<OpportunityTrackingData[]>([]); // State for fetched tracking data
+  const [loading, setLoading] = useState(false); // Loading state
+  const [error, setError] = useState<string | null>(null); // Error state
+
+  const months = [
+    "Jan", "Feb", "Mar", "Apr", "May", "June", 
+    "July", "Aug", "Sept", "Oct", "Nov", "Dec",
+  ];
+
+  // Fetch opportunity stats when the modal opens
+  useEffect(() => {
+    if (!open) return;
+
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error } = await FetchOpportunityStats(opportunity_id);
+        if (error) {
+          throw new Error(error);
+        }
+        setOpportunityData(data || []); // Store fetched data or empty array
+      } catch (err) {
+        console.error("Error fetching opportunity stats:", err);
+        setError("Failed to fetch opportunity stats.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [open, opportunity_id]);
+
+  // Transform the tracking data into the dataset for the chart
+  const dataset = useMemo(() => {
+    return months.map((month, index) => {
+      const trackingData = opportunityData.find(
+        (entry) => entry.month === index + 1 // Match month number (1-based index)
+      );
+
+      return {
+        month,
+        rejected: trackingData?.rejected || 0,
+        oa: trackingData?.online_assessment || 0,
+        interviewing: trackingData?.interviewing || 0,
+        offered: trackingData?.offer || 0,
+        initial_screen: trackingData?.applied || 0,
+      };
+    });
+  }, [opportunityData, months]);
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      aria-labelledby="application-stats-modal-title"
+      aria-describedby="application-stats-modal-description"
+    >
+      <Box sx={style}>
+        {loading ? (
+          <CircularProgress />
+        ) : error ? (
+          <Typography color="error">{error}</Typography>
+        ) : opportunityData.length > 0 ? (
+          <>
+            <Typography variant="h6" component="h2">
+              Opportunity Stats
+            </Typography>
+            <BarChart
+              dataset={dataset}
+              xAxis={[{ scaleType: "band", dataKey: "month" }]}
+              series={[
+                { dataKey: "initial_screen", label: "Initial Screen", color: "#769FCD" },
+                { dataKey: "rejected", label: "Rejected", color: "#C7253E" },
+                { dataKey: "oa", label: "OA", color: "#EB5B00" },
+                { dataKey: "interviewing", label: "Interviewing", color: "#F0A202" },
+                { dataKey: "offered", label: "Offered", color: "#2E7E33" },
+              ]}
+              width={600}
+              height={400}
+            />
+          </>
+        ) : (
+          <Typography>No data available</Typography>
+        )}
+      </Box>
+    </Modal>
+  );
+}

--- a/client/src/ui/track/JobCard.tsx
+++ b/client/src/ui/track/JobCard.tsx
@@ -14,6 +14,7 @@ import { Application, useTrack, ApplicationStage } from "@/lib/store/track";
 import { Profile } from "@/lib/store/profile";
 import { useFetchCompanyLogo } from "@/lib/hooks/useFetchCompanyLogo";
 import { useAlert } from "@/lib/store/alert";
+import { ApplicationStatsModal } from "@/ui/track/ApplicationStatsModal";
 import ApplicationDelete from "@/ui/track/ApplicationDeleteModal";
 
 // TODO:
@@ -74,6 +75,16 @@ export function JobCard({ application, profile, onCardClick, setPreventClick }: 
   const handleCloseDeleteApplicationModal = () => {
     setPreventClick?.(false);
     setDeleteApplicationModalOpen(false);
+  };
+
+  const [statsModalOpen, setStatsModalOpen] = useState(false);
+  const handleOpenStatsModal = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setStatsModalOpen(true);
+  };
+
+  const handleCloseStatsModal = () => {
+    setStatsModalOpen(false);
   };
   return (
     <>
@@ -249,7 +260,7 @@ export function JobCard({ application, profile, onCardClick, setPreventClick }: 
               padding: "6px",
               borderRadius: "50%",
             }}
-            onClick={(e) => e.stopPropagation()}
+            onClick={handleOpenStatsModal}
           >
             <FontAwesomeIcon
               icon={faChartColumn}
@@ -301,6 +312,12 @@ export function JobCard({ application, profile, onCardClick, setPreventClick }: 
         application={application}
         profile={profile}
         status={status}
+      />
+    {/* Stats Modal */}
+    <ApplicationStatsModal
+        open={statsModalOpen}
+        onClose={handleCloseStatsModal}
+        opportunity_id={application.opportunity_id}
       />
     </>
   );


### PR DESCRIPTION
This PR is responsible for the job card stats, it is similar to explore page stats modal.
Keep in mind that I could not reuse Opportunity Stats Modal from the explore page since it is there was some logic of opportunity stats modal from the explore base that cant communicate with the track page. So a new modal was created, it is the same logic returning modal just the opportunity stats, but the parameter and fetching system a bit different.
